### PR TITLE
Only apply h-100 to homepage

### DIFF
--- a/src/components/card/card.component.jsx
+++ b/src/components/card/card.component.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 class Card extends Component {
   render() {
     return (
-      <div className="h-100 w-100 card text-white bg-dark mb-3 d-inline-block">
+      <div className={`w-100 card text-white bg-dark mb-3 d-inline-block ${this.props.cardClasses}`}>
         {this.props.header ? (
           <div className="card-header">
             <h4>{this.props.header}</h4>
@@ -13,7 +13,7 @@ class Card extends Component {
           <h6 className="card-subtitle m-2 ml-3 text-muted">{this.props.subtitle}</h6>
         ) : ''}
         {this.props.body || this.props.text || this.props.title || this.props.textSubtitle ? (
-          <div className="card-body h-100 d-flex flex-column">
+          <div className={`card-body d-flex flex-column ${this.props.bodyClasses}`}>
             {this.props.title ? (
               <h4 className="card-title">
                 {this.props.title}

--- a/src/pages/homepage/columns/community-list.component.jsx
+++ b/src/pages/homepage/columns/community-list.component.jsx
@@ -36,6 +36,8 @@ class CommunityList extends Component {
                 <Card
                   title={community.name}
                   textSubtitle={community.district}
+                  cardClasses={'h-100'}
+                  bodyClasses={'h-100'}
                   body={
                     <Button className={'mt-auto'} href={`/community/${community.communityId}`}>
                       View


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Add properties to apply classes to card and card-body
<!-- Describe your changes in detail -->

## 📄 Motivation and Context
The h-100 made the cards in other pages (community for example) way too long
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

<!-- Please provide a screenshot of your change -->

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
