### PR TITLE
#90 - Fix sidebar show even if it is not opened

### DIFF
--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -40,7 +40,6 @@ const Bar = styled.div`
   padding: 20px 10px 20px 0;
   border-right: 3px solid ${styles.colors.grey};
 
-  left: -100%;
   display: initial;
   z-index: 2;
   height: ${styles.variables.viewHeight};
@@ -49,9 +48,10 @@ const Bar = styled.div`
   @media screen and (max-width: 600px) {
     position: absolute;
     transition: left .5s;
+    display: none;
 
     ${props => props.overlay && css`
-      left: 0;
+      display: initial;
     `}
   }
 `;

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -47,7 +47,6 @@ const Bar = styled.div`
 
   @media screen and (max-width: 600px) {
     position: absolute;
-    transition: left .5s;
     display: none;
 
     ${props => props.overlay && css`


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

I believe that working with the `display` property would be better than the `left` property.
I used the `display` property to be manipulated when the width is less than 600px.

## 📄 Motivation and Context

#90 

## 🧪 How Has This Been Tested?

I used the chrome developer tools to test the screen _smaller_ than 600px.

## 📷 Screenshots (if appropriate)

![closed](https://user-images.githubusercontent.com/17882257/96473330-e3bfc900-1207-11eb-883e-c9d71d61c775.png)
![open](https://user-images.githubusercontent.com/17882257/96473326-e3273280-1207-11eb-90bf-7468c4048dde.png)

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
