### PR TITLE
Replace url in Link - /signup to /login in SignUp.jsx

### DIFF
--- a/src/pages/sign-in-and-sign-up/SignUp.jsx
+++ b/src/pages/sign-in-and-sign-up/SignUp.jsx
@@ -140,7 +140,7 @@ class SignUp extends Component {
         }
         footer={
           <Text type="paragraph" textAlign="center">
-            Already have an account? <Link to="/signup">Log In</Link>
+            Already have an account? <Link to="/login">Log In</Link>
           </Text>
         }
       />


### PR DESCRIPTION
## 🚀 Description

Fixes issue #114

Replace the url in the `to` prop that is passed in to the `Link` component in `SignUp.jsx`

## 📄 Motivation and Context

This is so the user is able to login using their credentials if they have already signed up

## 🧪 How Has This Been Tested?

Ran `npm run test` and all tests have passed ✅ 

## 📷 Screenshots (if appropriate)

<img width="498" alt="Screen Shot 2021-02-14 at 11 57 39 PM" src="https://user-images.githubusercontent.com/16032631/107919628-7f481880-6f20-11eb-9f2c-17ff4c52926a.png">

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
