### PR TITLE
fixed the signup typos #213

### DIFF
--- a/src/pages/sign-in-and-sign-up/SignUp.jsx
+++ b/src/pages/sign-in-and-sign-up/SignUp.jsx
@@ -48,14 +48,14 @@ class SignUp extends Component {
         errors[id] = 'Field is required';
       }
       if ((id === 'confirmPassword' && value !== this.state.password) || (id === 'password' && value !== this.state.confirmPassword)) {
-        errors['confirmPassword'] = 'Password don\'t match';
+        errors['confirmPassword'] = 'Password does not match';
       }
       if (id === 'password' && !(value.length > 6)) {
-        errors[id] = 'Password needs to have between x and y characters';
+        errors[id] = 'The password should be at least 8 characters long';
       }
   
       if (id === 'email' && !value.match(/^[-!#$%&'*+/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+/0-9=?A-Z^_a-z{|}~])*@[a-zA-Z](-?[a-zA-Z0-9])*(\.[a-zA-Z](-?[a-zA-Z0-9])*)+$/)) {
-        errors[id] = 'Email adress is not valid';
+        errors[id] = 'Email address is not valid';
       }
     }
     return errors;


### PR DESCRIPTION
Fixed #213  

Solves the spelling errors on the signup page.

BEFORE:
<img width="289" alt="image" src="https://github.com/jmprathab/MyHome-Web/assets/60290121/5d93b69c-ed2e-43cd-8fa8-42778acde284">

AFTER:
<img width="297" alt="image" src="https://github.com/jmprathab/MyHome-Web/assets/60290121/d04cda48-ac92-4e36-9694-aaeb206e82ae">




- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
